### PR TITLE
refactor (remove await use) and add a new currency

### DIFF
--- a/components/Graph.web.js
+++ b/components/Graph.web.js
@@ -14,26 +14,17 @@ export default function Graph() {
     const [rates, setRates] = useState()
 
     async function recoverHistoricRates() {
-        let arr = await HistoricRatesGet(currOrigen, period)
-        if (arr === undefined) { return }
-        let processedRates = []
-
-        for (let i = 0; i < arr.length; i++) {
-            let obj = arr[i]
-            processedRates.push({ x: obj.date, y: obj.rates.find((el) => el.id === currDestiny).value })
-
-        }
-        /*
-                arr.forEach((obj) => {
-                    console.log("ARR RET OBJ ", obj)
-                    processedRates.push({ x: obj.date, y: obj.rates.find((el) => el.id === currDestiny).value })
-                })
-          */
-        setRates(processedRates)
+        return HistoricRatesGet(currOrigen, period)
+            .then((data) => data
+                .map(({date, rates}) => ({
+                    x: date,
+                    y: rates.find((el) => el.id === currDestiny).value
+                }))
+            )
     }
 
     useEffect(() => {
-        recoverHistoricRates()
+        recoverHistoricRates().then(setRates)
     }, [period, currOrigen, currDestiny])
 
 

--- a/static/currencies.json
+++ b/static/currencies.json
@@ -46,5 +46,9 @@
     {
         "key": "MXN",
         "value": "MXN - Peso mexicano"
+    },
+    {
+        "key": "COP",
+        "value": "COP - peso colombiano"
     }
 ]

--- a/static/currencies.json
+++ b/static/currencies.json
@@ -49,6 +49,6 @@
     },
     {
         "key": "COP",
-        "value": "COP - peso colombiano"
+        "value": "COP - Peso colombiano"
     }
 ]


### PR DESCRIPTION
Hola, espero que estés bien. Hace unos días vi tu video trabajando con promesas y por un momento me motivé a hacer un PR, pero desistí. Luego ví que te hicieron uno, así que me motivé a proponer algunos cambios. Hice tres cosas:

- Añadir el peso colombiano a la lista de divisas (soy colombiano XD)
- Eliminar el uso de `await` y bloques `try`-`catch` en 3 funciones: `HistoricRatesGet`, `CurrencyRatesGET` y `recoverHistoricRates`. También reemplacé los ciclos `for` con el uso de `map`. Esto, en mi opinión, deja código más limpio.
- Pasar la llamada a `setRates` de `recoverHistoryRates` al `useEffect` que hay abajo. Creo que esto hace que el nombre de la función sea congruente con lo que hace.

Mi motivación para reemplazar el uso de `await` del todo con el encademiento de `then` es que, como en este caso solo estás haciendo una secuencia de transformaciones a datos, es más fácil ver esto como una secuencia de `then` juntos.

También quería mencionar una cuestión sobre hacer un `Promise.all` tras otro: es potencialmente más lento. Las transformaciones que haces a los datos son independientes entre si, así que no tiene sentido esperar a que todas terminen un paso para seguir con el otro. Es mejor esperar a que todas terminen todos los pasos.

Me puse a buscar algo de debate sobre el uso de `await` con bloques `try`-`catch` vs. `.then` y `.catch`, y parece hay una gran preferencia por `await`. Esa no es mi posición, jaja. Creo que [este artículo](https://uniqname.medium.com/why-i-avoid-async-await-7be98014b73e) resume mis posiciones al respecto bastante bien.

Bueno, eso es todo de mi parte. ¡Saludos! Recientemente me encontré tu canal y me gusta.